### PR TITLE
fix: Image-Tag v0.2.0 is not (publicly) available. Changed to nightly build as default.

### DIFF
--- a/charts/satisfactory/values.yaml
+++ b/charts/satisfactory/values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: ""
 nameOverride: ""
 satisfactory:
-  image: "ghcr.io/andre161292/satisfactory-server:v0.2.0"
+  image: "ghcr.io/andre161292/satisfactory-server:main"
   maxPlayers: 5
   skipUpdate: false
   beta: false


### PR DESCRIPTION
Might not be the best idea to set it to the main tags, but at least helps running the chart out of the box 